### PR TITLE
🎨 Remove problematic self message style overrides (Issue #85)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2171,9 +2171,7 @@ body {
   font-size: 0.9em;
 }
 
-.own-message .message-content code {
-  background: rgba(255, 255, 255, 0.2);
-}
+/* Removed: .own-message .message-content code override - use consistent styling */
 
 .message-content pre {
   background: rgba(0, 0, 0, 0.05);
@@ -2184,10 +2182,7 @@ body {
   border-left: 3px solid rgba(102, 126, 234, 0.3);
 }
 
-.own-message .message-content pre {
-  background: rgba(255, 255, 255, 0.1);
-  border-left-color: rgba(255, 255, 255, 0.4);
-}
+/* Removed: .own-message .message-content pre override - use consistent styling */
 
 .message-content pre code {
   background: none;
@@ -2203,9 +2198,7 @@ body {
   opacity: 0.9;
 }
 
-.own-message .message-content blockquote {
-  border-left-color: rgba(255, 255, 255, 0.4);
-}
+/* Removed: .own-message .message-content blockquote override - use consistent styling */
 
 .message-content ul,
 .message-content ol {
@@ -2251,11 +2244,7 @@ body {
   animation: mentionPulse 0.5s ease-out;
 }
 
-.own-message .mention-highlight {
-  background: rgba(255, 255, 255, 0.3);
-  color: #fff;
-  border-color: rgba(255, 255, 255, 0.4);
-}
+/* Removed: .own-message .mention-highlight override - use consistent styling */
 
 /* 🚨 DISCORD-STYLE: High-contrast mention colors for all themes */
 .mention {


### PR DESCRIPTION
## 🎯 **Self Message Style Override Cleanup**

**Closes #85**

### ✅ **What's Fixed:**

#### 📝 **Code Block Styling:**
- **Removed** `.own-message .message-content code` white background override
- **Consistent styling** for inline code across all messages
- **No more visual inconsistencies** between sender types

#### 📄 **Pre Block Styling:**
- **Removed** `.own-message .message-content pre` white background/border override
- **Unified appearance** for code blocks in all messages
- **Clean, professional look** without distracting white borders

#### 💬 **Blockquote Styling:**
- **Removed** `.own-message .message-content blockquote` white border override
- **Consistent quote styling** regardless of message sender
- **Better visual hierarchy** with unified border colors

#### 🏷️ **Mention Highlight Styling:**
- **Removed** `.own-message .mention-highlight` white background override
- **Consistent mention styling** across all message types
- **Better readability** with unified highlight colors

### 🔍 **Root Cause Analysis:**

The issue was caused by specific CSS overrides for `.own-message` (current user messages) that applied different styling:

```css
/* REMOVED - These were causing visual inconsistencies */
.own-message .message-content code {
  background: rgba(255, 255, 255, 0.2); /* White background */
}

.own-message .message-content pre {
  background: rgba(255, 255, 255, 0.1); /* White background */
  border-left-color: rgba(255, 255, 255, 0.4); /* White border */
}

.own-message .message-content blockquote {
  border-left-color: rgba(255, 255, 255, 0.4); /* White border */
}

.own-message .mention-highlight {
  background: rgba(255, 255, 255, 0.3); /* White background */
  color: #fff;
  border-color: rgba(255, 255, 255, 0.4); /* White border */
}
```

### 🎨 **Visual Impact:**

#### Before:
- **Inconsistent styling** between current user and other messages
- **White borders and backgrounds** on code blocks in self messages
- **Poor readability** due to conflicting color schemes
- **Unprofessional appearance** with mixed styling approaches

#### After:
- **Unified visual language** across all message types
- **Consistent theming** for code blocks, quotes, and mentions
- **Better readability** with coherent color schemes
- **Professional Discord-style appearance** throughout

### 🛠️ **Technical Implementation:**

#### Approach:
- **Removed problematic overrides** rather than adding more CSS
- **Leveraged existing base styles** for consistency
- **Maintained all functionality** while improving appearance
- **No breaking changes** to existing behavior

#### Files Changed:
- `src/index.css` - Removed 4 problematic `.own-message` style overrides

### 🧪 **Testing:**

- ✅ **Visual consistency** verified across all message types
- ✅ **Code block styling** uniform for all senders
- ✅ **Blockquote styling** consistent across messages
- ✅ **Mention highlighting** working uniformly
- ✅ **Theme compatibility** maintained with Lumi Brand theme
- ✅ **No functional regressions** in message display

### 📊 **Performance:**

- **Reduced CSS complexity** by removing unnecessary overrides
- **Smaller CSS bundle** with fewer conflicting rules
- **Improved maintainability** with unified styling approach
- **Better theme consistency** across all components

### 📋 **User Experience:**

- **Improved readability** for code blocks in all messages
- **Consistent visual experience** regardless of message sender
- **Professional appearance** matching Discord-style design
- **Better accessibility** with unified color schemes

---

**The self message styling inconsistencies are now completely resolved!** 🎨✨

**This addresses the specific issue @Caleb mentioned about white borders on code blocks in current user messages.**

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author